### PR TITLE
Encode cc-streaming-cal-contacts-data

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -28,11 +28,10 @@ jobs:
         uses: actions-mn/cache@v1
 
       - name: Metanorma generate site
-        uses: actions-mn/build-and-publish@main
+        uses: actions-mn/build-and-publish@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           agree-to-terms: true
-
+          destination: gh-pages
   deploy:
     if: ${{ github.ref == 'refs/heads/main' }}
     environment:

--- a/README.adoc
+++ b/README.adoc
@@ -1,22 +1,21 @@
-= CalConnect Standard: (TITLE)
+= CalConnect Standard: Streaming Calendar and Contacts Data
 
-This work item belongs to CalConnect (TCs).
+This work item belongs to CalConnect CALENDAR TC.
 
 image:https://github.com/CalConnect/cc-streaming-cal-contacts-data/workflows/generate/badge.svg["Build Status", link="https://github.com/CalConnect/cc-streaming-cal-contacts-data/actions?workflow=generate"]
 
 This document is available in its rendered forms here:
 
-* https://calconnect.github.io/cc-streaming-cal-contacts-data/[CalConnect: Calendaring and scheduling -- Vocabulary (HTML)]
+* https://calconnect.github.io/cc-streaming-cal-contacts-data/[CalConnect: Streaming Calendar and Contacts Data (HTML)]
 
 == General
 
-This document specifies the (TITLE).
+This document specifies a model for streaming calendar and contact data. This allows for a more efficient method for synchronizing collections of data and may be used to augment existing protocols such as CalDAV.
 
 The document is published as the following:
 
-* CalConnect CC (DOCNUMBER)
-* ISO (DOCNUMBER)
-* IETF draft-cc-streaming-cal-contacts-data
+* CalConnect CC 51016
+* IETF draft-douglass-streaming-cal-contacts-data
 
 
 == Fetching the document
@@ -62,17 +61,6 @@ The generated documents are accessible under `_site/`.
 metanorma site generate --agree-to-terms
 open _site/index.html
 ----
-
-
-// == IETF: Checking against idnits
-
-// https://tools.ietf.org/tools/idnits/[idnits] is the RFC checking tool prior to
-// submissions.
-
-// [source,sh]
-// ----
-// idnits draft-calconnect-vobject-vformat.nits
-// ----
 
 
 == License

--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ This document is available in its rendered forms here:
 
 == General
 
-This document specifies a model for streaming calendar and contact data. This allows for a more efficient method for synchronizing collections of data and may be used to augment existing protocols such as CalDAV.
+This document specifies the Streaming Calendar and Contacts Data.
 
 The document is published as the following:
 

--- a/metanorma.yml
+++ b/metanorma.yml
@@ -2,10 +2,9 @@
 metanorma:
   source:
     files:
-      - sources/cc-51008/document.adoc
-      - sources/ietf/document.adoc
-      - sources/iso-51008/document.adoc
+      - sources/cc-51016.adoc
+      - sources/draft-douglass-streaming-cal-contacts-data.adoc
 
   collection:
-    name: vObject and vFormat
     organization: CalConnect
+    name: Streaming Calendar and Contacts Data

--- a/sources/cc-51016.adoc
+++ b/sources/cc-51016.adoc
@@ -28,6 +28,8 @@ include::sections/02-normative-references.adoc[]
 
 include::sections/03-terms.adoc[]
 
+include::sections/03-conventions.adoc[]
+
 include::sections/04-connections.adoc[]
 
 include::sections/05-icalendar-changes.adoc[]

--- a/sources/cc-51016.adoc
+++ b/sources/cc-51016.adoc
@@ -1,0 +1,41 @@
+= Streaming Calendar and Contacts Data
+:docnumber: 51016
+:copyright-year: 2018
+:language: en
+:doctype: standard
+:edition: 1
+:status: working-draft
+:revdate: 2018-08-01
+:published-date: 2018-08-01
+:technical-committee: CALENDAR
+:fullname: Michael Douglass
+:surname: Douglass
+:givenname: Michael
+:affiliation: Spherical Cow Group
+:mn-document-class: cc
+:mn-output-extensions: xml,html,pdf,rxl
+:keywords: icalendar, properties
+:local-cache-only:
+:data-uri-image:
+
+include::sections/00-abstract.adoc[]
+
+include::sections/01-intro.adoc[]
+
+include::sections/01-scope.adoc[]
+
+include::sections/02-normative-references.adoc[]
+
+include::sections/03-terms.adoc[]
+
+include::sections/04-connections.adoc[]
+
+include::sections/05-icalendar-changes.adoc[]
+
+include::sections/06-discovery.adoc[]
+
+include::sections/07-security.adoc[]
+
+include::sections/08-iana.adoc[]
+
+include::sections/99-acknowledgements.adoc[]

--- a/sources/draft-douglass-streaming-cal-contacts-data.adoc
+++ b/sources/draft-douglass-streaming-cal-contacts-data.adoc
@@ -1,0 +1,44 @@
+= Streaming Calendar and Contacts Data
+:doctype: internet-draft
+:name: draft-douglass-streaming-cal-contacts-data
+:status: standard
+:ipr: trust200902
+:area: Applications
+:intended-series: full-standard
+:workgroup: Calendaring Extensions
+:published-date: 2018-08-01
+:fullname: Michael Douglass
+:lastname: Douglass
+:forename_initials: M.
+:affiliation: Spherical Cow Group
+:address: 226 3rd Street + \
+Troy, NY 12180 + \
+USA
+:email: mdouglass@sphericalcowgroup.com
+:contributor-uri: http://sphericalcowgroup.com
+:updates: IETF RFC 5545
+:mn-document-class: ietf
+:mn-output-extensions: xml,rfc,txt,html,rxl
+:keywords: icalendar, properties
+:local-cache-only:
+:data-uri-image:
+
+include::sections-ietf/00-abstract.adoc[]
+
+include::sections/01-intro.adoc[]
+
+include::sections/04-connections.adoc[]
+
+include::sections/05-icalendar-changes.adoc[]
+
+include::sections/06-discovery.adoc[]
+
+include::sections/07-security.adoc[]
+
+include::sections/08-iana.adoc[]
+
+include::sections/99-acknowledgements.adoc[]
+
+include::sections-ietf/99-changelog.adoc[]
+
+include::sections-ietf/97-references.adoc[]

--- a/sources/draft-douglass-streaming-cal-contacts-data.adoc
+++ b/sources/draft-douglass-streaming-cal-contacts-data.adoc
@@ -25,7 +25,7 @@ USA
 
 include::sections-ietf/00-abstract.adoc[]
 
-include::sections/01-intro.adoc[]
+include::sections-ietf/01-intro.adoc[]
 
 include::sections/04-connections.adoc[]
 

--- a/sources/sections-ietf/00-abstract.adoc
+++ b/sources/sections-ietf/00-abstract.adoc
@@ -2,11 +2,11 @@
 == Abstract
 
 This specification defines a model for streaming calendar and contact data. This
-allows for a more efficient method for synchronizing collections of data and may be
-used to augment existing protocols such as CalDAV.
+allows for a more efficient method for synchronizing collections of data and may
+be used to augment existing protocols such as CalDAV.
 
 [NOTE,title=Open Issues]
 ====
-* restype values: Need to determine what if any registry of resource types already
-exists and use that.
+* restype values: Need to determine what if any registry of resource types
+already exists and use that.
 ====

--- a/sources/sections-ietf/00-abstract.adoc
+++ b/sources/sections-ietf/00-abstract.adoc
@@ -1,0 +1,12 @@
+[abstract]
+== Abstract
+
+This specification defines a model for streaming calendar and contact data. This
+allows for a more efficient method for synchronizing collections of data and may be
+used to augment existing protocols such as CalDAV.
+
+[NOTE,title=Open Issues]
+====
+* restype values: Need to determine what if any registry of resource types already
+exists and use that.
+====

--- a/sources/sections-ietf/01-intro.adoc
+++ b/sources/sections-ietf/01-intro.adoc
@@ -20,3 +20,9 @@ and defines the allowable operations.
 
 This specification will provide an approach to implementations using websockets
 or currently existing messaging systems such as JMS.
+
+=== Conventions Used in This Document
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in <<RFC2119>>.

--- a/sources/sections-ietf/97-references.adoc
+++ b/sources/sections-ietf/97-references.adoc
@@ -19,6 +19,6 @@
 
 * [[[RFC5988,IETF RFC 5988]]]
 
-* [[[W3C.REC-xml-20060816,W3C XML]]], W3C Recommendation, _Extensible Markup Language (XML) 1.0_, August 2006
+* [[[W3C.REC-xml-20060816,W3C TR XML]]], W3C Recommendation, _Extensible Markup Language (XML) 1.0_, August 2006
 
 * [[[I-D.ietf-calext-extensions,IETF I-D ietf-calext-extensions]]]

--- a/sources/sections-ietf/97-references.adoc
+++ b/sources/sections-ietf/97-references.adoc
@@ -1,0 +1,24 @@
+== References
+
+[bibliography]
+=== Normative References
+
+* [[[RFC2119,IETF RFC 2119]]]
+
+* [[[RFC2434,IETF RFC 2434]]]
+
+* [[[RFC3688,IETF RFC 3688]]]
+
+* [[[RFC3986,IETF RFC 3986]]]
+
+* [[[RFC4589,IETF RFC 4589]]]
+
+* [[[RFC5545,IETF RFC 5545]]]
+
+* [[[RFC5546,IETF RFC 5546]]]
+
+* [[[RFC5988,IETF RFC 5988]]]
+
+* [[[W3C.REC-xml-20060816,W3C XML]]], W3C Recommendation, _Extensible Markup Language (XML) 1.0_, August 2006
+
+* [[[I-D.ietf-calext-extensions,IETF I-D ietf-calext-extensions]]]

--- a/sources/sections-ietf/99-changelog.adoc
+++ b/sources/sections-ietf/99-changelog.adoc
@@ -1,0 +1,47 @@
+[appendix]
+== metanorma-extension
+
+=== document history
+
+[source,yaml]
+----
+- date:
+  - type: updated
+    value: 2017-07-28
+  edition: 1
+  contributor:
+  - person:
+      name:
+        abbreviation: MD
+        completename: Michael Douglass
+  amend:
+    - description: |
+        Examples
+
+        More text for extended get. Talk about deletions.
+- date:
+  - type: updated
+    value: 2017-07-17
+  edition: 1
+  contributor:
+  - person:
+      name:
+        abbreviation: MD
+        completename: Michael Douglass
+  amend:
+    - description: |
+        Add text about OPTIONS
+
+        Add text about read/write CalDAV
+- date:
+  - type: created
+    value: 2017-02-15
+  edition: 0
+  contributor:
+  - person:
+      name:
+        abbreviation: MD
+        completename: Michael Douglass
+  amend:
+    - description: First pass
+----

--- a/sources/sections/00-abstract.adoc
+++ b/sources/sections/00-abstract.adoc
@@ -2,5 +2,5 @@
 == Abstract
 
 This specification defines a model for streaming calendar and contact data. This
-allows for a more efficient method for synchronizing collections of data and may be
-used to augment existing protocols such as CalDAV.
+allows for a more efficient method for synchronizing collections of data and may
+be used to augment existing protocols such as CalDAV.

--- a/sources/sections/00-abstract.adoc
+++ b/sources/sections/00-abstract.adoc
@@ -1,0 +1,6 @@
+[abstract]
+== Abstract
+
+This specification defines a model for streaming calendar and contact data. This
+allows for a more efficient method for synchronizing collections of data and may be
+used to augment existing protocols such as CalDAV.

--- a/sources/sections/01-intro.adoc
+++ b/sources/sections/01-intro.adoc
@@ -1,0 +1,27 @@
+[[introduction]]
+== Introduction
+
+Currently clients or servers maintain a synchronized copy of external data through
+subscriptions and polling or by the use of protocol extensions such as DAV Sync Report.
+
+These methods in essence require polling at more or less regular intervals to detect
+changes. For more timely detection of changes, frequent polling is required. This
+leads to inefficiencies and costs in battery and network usage.
+
+The situation may be improved by the use of push notifications but this adds
+complications to the system.
+
+This specification introduces an approach whereby a clients opens streams and then
+simply writes to or reads from the stream. This is not conceptually a new invention.
+Messaging systems already provide such features. What this specification provides is
+the data structures which can be passed as messages and defines the allowable
+operations.
+
+This specification will provide an approach to implementations using websockets or
+currently existing messaging systems such as JMS.
+
+=== Conventions Used in This Document
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD
+NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to
+be interpreted as described in <<RFC2119>>.

--- a/sources/sections/01-scope.adoc
+++ b/sources/sections/01-scope.adoc
@@ -1,14 +1,6 @@
 [[scope]]
 == Scope
 
-//This document specifies a model for streaming calendar and contact data to enable
-//efficient synchronization of collections. It defines:
-
-//* A streaming model for calendar and contact data synchronization
-//* Changes to the iCalendar specifications to support streaming operations
-//* Methods for discovering alternative access methods
-//* Security and privacy considerations for streaming data
-//* New link relation types for different access protocols
-
-//This specification is designed to work with existing calendar and contact data formats
-//and protocols, particularly iCalendar and CalDAV.
+This specification defines a model for streaming calendar and contact data. This
+allows for a more efficient method for synchronizing collections of data and may
+be used to augment existing protocols such as CalDAV.

--- a/sources/sections/01-scope.adoc
+++ b/sources/sections/01-scope.adoc
@@ -1,0 +1,14 @@
+[[scope]]
+== Scope
+
+//This document specifies a model for streaming calendar and contact data to enable
+//efficient synchronization of collections. It defines:
+
+//* A streaming model for calendar and contact data synchronization
+//* Changes to the iCalendar specifications to support streaming operations
+//* Methods for discovering alternative access methods
+//* Security and privacy considerations for streaming data
+//* New link relation types for different access protocols
+
+//This specification is designed to work with existing calendar and contact data formats
+//and protocols, particularly iCalendar and CalDAV.

--- a/sources/sections/02-normative-references.adoc
+++ b/sources/sections/02-normative-references.adoc
@@ -17,6 +17,6 @@
 
 * [[[RFC5988,IETF RFC 5988]]]
 
-* [[[W3C.REC-xml-20060816,W3C XML]]], W3C Recommendation, _Extensible Markup Language (XML) 1.0_, August 2006
+* [[[W3C.REC-xml-20060816,W3C TR XML]]], W3C Recommendation, _Extensible Markup Language (XML) 1.0_, August 2006
 
 * [[[I-D.ietf-calext-extensions,IETF I-D ietf-calext-extensions]]]

--- a/sources/sections/02-normative-references.adoc
+++ b/sources/sections/02-normative-references.adoc
@@ -1,0 +1,22 @@
+[bibliography]
+== Normative References
+
+* [[[RFC2119,IETF RFC 2119]]]
+
+* [[[RFC2434,IETF RFC 2434]]]
+
+* [[[RFC3688,IETF RFC 3688]]]
+
+* [[[RFC3986,IETF RFC 3986]]]
+
+* [[[RFC4589,IETF RFC 4589]]]
+
+* [[[RFC5545,IETF RFC 5545]]]
+
+* [[[RFC5546,IETF RFC 5546]]]
+
+* [[[RFC5988,IETF RFC 5988]]]
+
+* [[[W3C.REC-xml-20060816,W3C XML]]], W3C Recommendation, _Extensible Markup Language (XML) 1.0_, August 2006
+
+* [[[I-D.ietf-calext-extensions,IETF I-D ietf-calext-extensions]]]

--- a/sources/sections/03-conventions.adoc
+++ b/sources/sections/03-conventions.adoc
@@ -1,0 +1,5 @@
+== Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in <<RFC2119>>.

--- a/sources/sections/03-terms.adoc
+++ b/sources/sections/03-terms.adoc
@@ -1,0 +1,2 @@
+== Terms and Definitions
+

--- a/sources/sections/03-terms.adoc
+++ b/sources/sections/03-terms.adoc
@@ -1,2 +1,2 @@
-== Terms and Definitions
+== Terms and definitions
 

--- a/sources/sections/04-connections.adoc
+++ b/sources/sections/04-connections.adoc
@@ -6,21 +6,21 @@
 This specification assumes that there are two virtual streams open for each
 established virtual connection: an output stream and an input stream.
 
-All operations are carried out by either end writing a message on the output stream
-and receiving an acknowledgment on the input stream.
+All operations are carried out by either end writing a message on the output
+stream and receiving an acknowledgment on the input stream.
 
-All messages MUST receive an acknowledgement within the defined timeout period or
-they or their acknowledgement will be assumed to have been lost. The sender will
-need to carry out any appropriate recovery.
+All messages MUST receive an acknowledgement within the defined timeout period
+or they or their acknowledgement will be assumed to have been lost. The sender
+will need to carry out any appropriate recovery.
 
 Each message sent MUST include a unique (within the connection) identifier which
 will be returned in the acknowledgment.
 
 === Virtual Connections
 
-The actual systems on which this is running may have many restrictions. Connections
-may be forcibly shut down after some idle time and there will be the usual issues
-with mobile devices and connectivity.
+The actual systems on which this is running may have many restrictions.
+Connections may be forcibly shut down after some idle time and there will be the
+usual issues with mobile devices and connectivity.
 
 The virtual connection MUST hide these issues from the client. A connection will
 last until one end is deemed to have shut down the connection.
@@ -31,8 +31,8 @@ On subsequent conditional fetches the entity will not be returned.
 
 [example]
 ====
-This is an example of the initial request and response from a server that supports
-the extended GET protocol.
+This is an example of the initial request and response from a server that
+supports the extended GET protocol.
 
 [source%unnumbered]
 ----
@@ -48,7 +48,7 @@ HTTP/1.1 200 OK
 Content-Length: xxxx
 ETag: "1234"                    current ETag (for conditional GET)
 Vary: Prefer, If-None-Match            so caching proxy can key off of client's ETag (sync token) and preference
- 
+
 BEGIN:VCALENDAR:
 ...  /* full feed */
 END:VCALENDAR
@@ -58,8 +58,8 @@ END:VCALENDAR
 [example]
 ====
 This is an example of the subsequent request and response when no changes have
-occurred. The Accept header field indicates that a VPATCH format is most desirable
-but simple text/calendar is acceptable.
+occurred. The Accept header field indicates that a VPATCH format is most
+desirable but simple text/calendar is acceptable.
 
 [source%unnumbered]
 ----
@@ -82,8 +82,8 @@ Vary: Prefer, If-None-Match
 
 [example]
 ====
-This is an example of the subsequent request and response when changes have occurred
-and the server can create the minimal format.
+This is an example of the subsequent request and response when changes have
+occurred and the server can create the minimal format.
 
 [source%unnumbered]
 ----
@@ -113,9 +113,9 @@ END:VCALENDAR
 
 [example]
 ====
-This is an example of the subsequent request and response when changes have occurred
-and the server cannot create the minimal format - perhaps because of an old or
-invalid token. Note there is no Preference-Applied header field.
+This is an example of the subsequent request and response when changes have
+occurred and the server cannot create the minimal format - perhaps because of an
+old or invalid token. Note there is no Preference-Applied header field.
 
 [source%unnumbered]
 ----

--- a/sources/sections/04-connections.adoc
+++ b/sources/sections/04-connections.adoc
@@ -1,0 +1,142 @@
+[[connections]]
+== Connections
+
+=== Introduction
+
+This specification assumes that there are two virtual streams open for each
+established virtual connection: an output stream and an input stream.
+
+All operations are carried out by either end writing a message on the output stream
+and receiving an acknowledgment on the input stream.
+
+All messages MUST receive an acknowledgement within the defined timeout period or
+they or their acknowledgement will be assumed to have been lost. The sender will
+need to carry out any appropriate recovery.
+
+Each message sent MUST include a unique (within the connection) identifier which
+will be returned in the acknowledgment.
+
+=== Virtual Connections
+
+The actual systems on which this is running may have many restrictions. Connections
+may be forcibly shut down after some idle time and there will be the usual issues
+with mobile devices and connectivity.
+
+The virtual connection MUST hide these issues from the client. A connection will
+last until one end is deemed to have shut down the connection.
+
+On subsequent conditional fetches the entity will not be returned.
+
+=== Examples
+
+[example]
+====
+This is an example of the initial request and response from a server that supports
+the extended GET protocol.
+
+[source%unnumbered]
+----
+>> Request <<
+
+GET /events.ics HTTP/1.1
+Host: example.com
+Accept: text/calendar
+
+>> Response <<
+
+HTTP/1.1 200 OK
+Content-Length: xxxx
+ETag: "1234"                    current ETag (for conditional GET)
+Vary: Prefer, If-None-Match            so caching proxy can key off of client's ETag (sync token) and preference
+ 
+BEGIN:VCALENDAR:
+...  /* full feed */
+END:VCALENDAR
+----
+====
+
+[example]
+====
+This is an example of the subsequent request and response when no changes have
+occurred. The Accept header field indicates that a VPATCH format is most desirable
+but simple text/calendar is acceptable.
+
+[source%unnumbered]
+----
+>> Request <<
+
+GET /events.ics HTTP/1.1
+Host: example.com
+Accept: text/calendar; q=0.5, component=VPATCH, text/calendar;
+If-None-Match: "1234"            conditional request
+Prefer: return=minimal
+
+>> Response <<
+
+HTTP/1.1 304 Not Modified
+Content-Length: 0
+ETag: "1234"
+Vary: Prefer, If-None-Match
+----
+====
+
+[example]
+====
+This is an example of the subsequent request and response when changes have occurred
+and the server can create the minimal format.
+
+[source%unnumbered]
+----
+>> Request <<
+
+GET /events.ics HTTP/1.1
+Host: example.com
+Accept: text/calendar; q=0.5, component=VPATCH, text/calendar;
+If-None-Match: "1234"            conditional request
+Prefer: return=minimal
+
+>> Response <<
+
+HTTP/1.1 200 OK
+Content-Type: text/calendar
+Content-Length: xxxx
+ETag: "5678"                    current ETag (for conditional GET)
+Preference-Applied: return=minimal    signals to client that stream is changes only
+Vary: Prefer, If-None-Match            so caching proxy can key off of client's ETag (sync token) and preference
+
+BEGIN:VCALENDAR:
+...  only new/changed events
+...  when not returning VPATCH, deleted events have STATUS:DELETED
+END:VCALENDAR
+----
+====
+
+[example]
+====
+This is an example of the subsequent request and response when changes have occurred
+and the server cannot create the minimal format - perhaps because of an old or
+invalid token. Note there is no Preference-Applied header field.
+
+[source%unnumbered]
+----
+>> Request <<
+
+GET /events.ics HTTP/1.1
+Host: example.com
+Accept: text/calendar; q=0.5, component=VPATCH, text/calendar;
+If-None-Match: "1234"            conditional request
+Prefer: return=minimal
+
+>> Response <<
+
+HTTP/1.1 200 OK
+Content-Type: text/calendar
+Content-Length: xxxx
+ETag: "5678"                    current ETag (for conditional GET)
+Vary: Prefer, If-None-Match            so caching proxy can key off of client's ETag (sync token) and preference
+
+BEGIN:VCALENDAR:
+...  full set of data
+END:VCALENDAR
+----
+====

--- a/sources/sections/05-icalendar-changes.adoc
+++ b/sources/sections/05-icalendar-changes.adoc
@@ -2,32 +2,32 @@
 == Changes to the iCalendar specifications
 
 This specification updates <<RFC5545>> to add the value DELETED to the STATUS
-property. It also introduces the use of some properties to provide more information
-about the resource, for example the time range it covers.
+property. It also introduces the use of some properties to provide more
+information about the resource, for example the time range it covers.
 
 === Redefined Status property
 
 Property name:: STATUS
 
-Purpose:: This property defines the overall status or confirmation for the calendar
-component.
+Purpose:: This property defines the overall status or confirmation for the
+calendar component.
 
 Value Type:: TEXT
 
-Property Parameters:: IANA and non-standard property parameters can be specified on
-this property.
+Property Parameters:: IANA and non-standard property parameters can be specified
+on this property.
 
 Conformance:: This property can be specified once in "VEVENT", "VTODO", or
 "VJOURNAL" calendar components.
 
-Description:: In a group-scheduled calendar component, the property is used by the
-"Organizer" to provide a confirmation of the event to the "Attendees". For example
-in a "VEVENT" calendar component, the "Organizer" can indicate that a meeting is
-tentative, confirmed, cancelled, or deleted. In a "VTODO" calendar component, the
-"Organizer" can indicate that an action item needs action, is completed, is in
-process or being worked on, has been cancelled, or has been deleted. In a "VJOURNAL"
-calendar component, the "Organizer" can indicate that a journal entry is draft,
-final, cancelled, or deleted.
+Description:: In a group-scheduled calendar component, the property is used by
+the "Organizer" to provide a confirmation of the event to the "Attendees". For
+example in a "VEVENT" calendar component, the "Organizer" can indicate that a
+meeting is tentative, confirmed, cancelled, or deleted. In a "VTODO" calendar
+component, the "Organizer" can indicate that an action item needs action, is
+completed, is in process or being worked on, has been cancelled, or has been
+deleted. In a "VJOURNAL" calendar component, the "Organizer" can indicate that a
+journal entry is draft, final, cancelled, or deleted.
 
 Format Definition:: This property is defined by the following notation:
 +

--- a/sources/sections/05-icalendar-changes.adoc
+++ b/sources/sections/05-icalendar-changes.adoc
@@ -1,0 +1,84 @@
+[[icalendar-changes]]
+== Changes to the iCalendar specifications
+
+This specification updates <<RFC5545>> to add the value DELETED to the STATUS
+property. It also introduces the use of some properties to provide more information
+about the resource, for example the time range it covers.
+
+=== Redefined Status property
+
+Property name:: STATUS
+
+Purpose:: This property defines the overall status or confirmation for the calendar
+component.
+
+Value Type:: TEXT
+
+Property Parameters:: IANA and non-standard property parameters can be specified on
+this property.
+
+Conformance:: This property can be specified once in "VEVENT", "VTODO", or
+"VJOURNAL" calendar components.
+
+Description:: In a group-scheduled calendar component, the property is used by the
+"Organizer" to provide a confirmation of the event to the "Attendees". For example
+in a "VEVENT" calendar component, the "Organizer" can indicate that a meeting is
+tentative, confirmed, cancelled, or deleted. In a "VTODO" calendar component, the
+"Organizer" can indicate that an action item needs action, is completed, is in
+process or being worked on, has been cancelled, or has been deleted. In a "VJOURNAL"
+calendar component, the "Organizer" can indicate that a journal entry is draft,
+final, cancelled, or deleted.
+
+Format Definition:: This property is defined by the following notation:
++
+[source%unnumbered]
+----
+status          = "STATUS" statparam ":" statvalue CRLF
+
+statparam       = *(";" other-param)
+
+statvalue       = (statvalue-event
+                /  statvalue-todo
+                /  statvalue-jour)
+
+statvalue-event = "TENTATIVE"    ;Indicates event is tentative.
+                / "CONFIRMED"    ;Indicates event is definite.
+                / "CANCELLED"    ;Indicates event was cancelled.
+                / "DELETED"      ;Indicates event was deleted.
+;Status values for a "VEVENT"
+
+statvalue-todo  = "NEEDS-ACTION" ;Indicates to-do needs action.
+                / "COMPLETED"    ;Indicates to-do completed.
+                / "IN-PROCESS"   ;Indicates to-do in process of.
+                / "CANCELLED"    ;Indicates to-do was cancelled.
+                / "DELETED"      ;Indicates to-do was deleted.
+;Status values for "VTODO".
+
+statvalue-jour  = "DRAFT"        ;Indicates journal is draft.
+                / "FINAL"        ;Indicates journal is final.
+                / "CANCELLED"    ;Indicates journal is removed.
+                / "DELETED"      ;Indicates journal was deleted.
+;Status values for "VJOURNAL".
+----
+
+Example:: The following is an example of this property for a "VEVENT" calendar
+component:
++
+[source%unnumbered]
+----
+STATUS:TENTATIVE
+----
++
+The following is an example of this property for a "VTODO" calendar component:
++
+[source%unnumbered]
+----
+STATUS:NEEDS-ACTION
+----
++
+The following is an example of this property for a "VJOURNAL" calendar component:
++
+[source%unnumbered]
+----
+STATUS:DRAFT
+----

--- a/sources/sections/06-discovery.adoc
+++ b/sources/sections/06-discovery.adoc
@@ -1,0 +1,51 @@
+[[discovery]]
+== Discovering alternative access methods
+
+The advertising of other access points is achieved through the use of the LINK
+header as defined in <<RFC5988>>. New link relation types are defined in this
+specification - each being associated with a protocol or protocol subset.
+
+These LINK headers will be delivered when a client carries out an OPTIONS request
+targeting the URL of the resource.
+
+[[link_relation_subscribe_caldav]]
+=== Link relation subscribe-caldav
+
+This specifies an access point which is a full implementation of caldav but requires
+no authentication. The end point allows the full range of reports as defined by the
+CalDAV specification.
+
+The client MUST follow the specification to determine exactly what operations are
+allowed on the access point - for example to determine if sync-report is supported.
+
+The URL MAY include some form of token to allow write access to the targeted
+collection. The client must check it's permissions to determine whether or not it
+has been granted write access.
+
+[[link_relation_subscribe_caldav_auth]]
+=== Link relation subscribe-caldav-auth
+
+This specifies an access point which is a full implementation of caldav and requires
+authentication. This may allow read-write access to the resource.
+
+The client MUST follow the specification to determine exactly what operations are
+allowed on the access point - for example to determine if sync-report is supported.
+
+[[link_relation_subscribe_webdav_sync]]
+=== Link relation subscribe-webdav-sync
+
+This specifies an access point which supports only webdav sync.
+
+This allows the client to issue a sync-report on the resource to obtain updates.
+
+NOTE: Initial startup may require using ics to populate and obtain initial token.
+
+The client MUST follow that specification.
+
+[[link_relation_subscribe_enhanced_get]]
+=== Link relation subscribe-enhanced-get
+
+This specifies an access point which supports enhanced GET functionality as defined
+in this specification.
+
+The client MUST follow that specification.

--- a/sources/sections/06-discovery.adoc
+++ b/sources/sections/06-discovery.adoc
@@ -5,31 +5,33 @@ The advertising of other access points is achieved through the use of the LINK
 header as defined in <<RFC5988>>. New link relation types are defined in this
 specification - each being associated with a protocol or protocol subset.
 
-These LINK headers will be delivered when a client carries out an OPTIONS request
-targeting the URL of the resource.
+These LINK headers will be delivered when a client carries out an OPTIONS
+request targeting the URL of the resource.
 
 [[link_relation_subscribe_caldav]]
 === Link relation subscribe-caldav
 
-This specifies an access point which is a full implementation of caldav but requires
-no authentication. The end point allows the full range of reports as defined by the
-CalDAV specification.
+This specifies an access point which is a full implementation of caldav but
+requires no authentication. The end point allows the full range of reports as
+defined by the CalDAV specification.
 
-The client MUST follow the specification to determine exactly what operations are
-allowed on the access point - for example to determine if sync-report is supported.
+The client MUST follow the specification to determine exactly what operations
+are allowed on the access point - for example to determine if sync-report is
+supported.
 
 The URL MAY include some form of token to allow write access to the targeted
-collection. The client must check it's permissions to determine whether or not it
-has been granted write access.
+collection. The client must check it's permissions to determine whether or not
+it has been granted write access.
 
 [[link_relation_subscribe_caldav_auth]]
 === Link relation subscribe-caldav-auth
 
-This specifies an access point which is a full implementation of caldav and requires
-authentication. This may allow read-write access to the resource.
+This specifies an access point which is a full implementation of caldav and
+requires authentication. This may allow read-write access to the resource.
 
-The client MUST follow the specification to determine exactly what operations are
-allowed on the access point - for example to determine if sync-report is supported.
+The client MUST follow the specification to determine exactly what operations
+are allowed on the access point - for example to determine if sync-report is
+supported.
 
 [[link_relation_subscribe_webdav_sync]]
 === Link relation subscribe-webdav-sync
@@ -38,14 +40,15 @@ This specifies an access point which supports only webdav sync.
 
 This allows the client to issue a sync-report on the resource to obtain updates.
 
-NOTE: Initial startup may require using ics to populate and obtain initial token.
+NOTE: Initial startup may require using ics to populate and obtain initial
+token.
 
 The client MUST follow that specification.
 
 [[link_relation_subscribe_enhanced_get]]
 === Link relation subscribe-enhanced-get
 
-This specifies an access point which supports enhanced GET functionality as defined
-in this specification.
+This specifies an access point which supports enhanced GET functionality as
+defined in this specification.
 
 The client MUST follow that specification.

--- a/sources/sections/07-security.adoc
+++ b/sources/sections/07-security.adoc
@@ -1,0 +1,15 @@
+[[security]]
+== Security Considerations
+
+Applications using these properties need to be aware of the risks entailed in using
+the URIs provided as values. See <<RFC3986>> for a discussion of the security
+considerations relating to URIs.
+
+[[privacy]]
+== Privacy Considerations
+
+Properties with a "URI" value type can expose their users to privacy leaks as any
+network access of the URI data can be tracked. Clients SHOULD NOT automatically
+download data referenced by the URI without explicit instruction from users. This
+specification does not introduce any additional privacy concerns beyond those
+described in <<RFC5545>>.

--- a/sources/sections/07-security.adoc
+++ b/sources/sections/07-security.adoc
@@ -1,15 +1,15 @@
 [[security]]
 == Security Considerations
 
-Applications using these properties need to be aware of the risks entailed in using
-the URIs provided as values. See <<RFC3986>> for a discussion of the security
-considerations relating to URIs.
+Applications using these properties need to be aware of the risks entailed in
+using the URIs provided as values. See <<RFC3986>> for a discussion of the
+security considerations relating to URIs.
 
 [[privacy]]
 == Privacy Considerations
 
-Properties with a "URI" value type can expose their users to privacy leaks as any
-network access of the URI data can be tracked. Clients SHOULD NOT automatically
-download data referenced by the URI without explicit instruction from users. This
-specification does not introduce any additional privacy concerns beyond those
-described in <<RFC5545>>.
+Properties with a "URI" value type can expose their users to privacy leaks as
+any network access of the URI data can be tracked. Clients SHOULD NOT
+automatically download data referenced by the URI without explicit instruction
+from users. This specification does not introduce any additional privacy
+concerns beyond those described in <<RFC5545>>.

--- a/sources/sections/08-iana.adoc
+++ b/sources/sections/08-iana.adoc
@@ -1,0 +1,28 @@
+[[iana-considerations]]
+== IANA Considerations
+
+=== Link Relation Registrations
+
+This document defines the following new iCalendar properties to be added to the
+registry defined in <<RFC5545,section=8.2.3>>:
+
+[cols="3",options="header"]
+|===
+|Relation Name |Description |Reference
+
+|subscribe-caldav
+|Current
+|RFCXXXX, <<link_relation_subscribe_caldav>>
+
+|subscribe-caldav-auth
+|Current
+|RFCXXXX, <<link_relation_subscribe_caldav_auth>>
+
+|subscribe-webdav-sync
+|Current
+|RFCXXXX, <<link_relation_subscribe_webdav_sync>>
+
+|subscribe-enhanced-get
+|Current
+|RFCXXXX, <<link_relation_subscribe_enhanced_get>>
+|===

--- a/sources/sections/99-acknowledgements.adoc
+++ b/sources/sections/99-acknowledgements.adoc
@@ -1,9 +1,9 @@
 [acknowledgments]
 == Acknowledgements
 
-The author would also like to thank the members of the CalConnect Calendar Sharing
-technical committee and the following individuals for contributing their ideas and
-support:
+The author would also like to thank the members of the CalConnect Calendar
+Sharing technical committee and the following individuals for contributing their
+ideas and support:
 
 Marten Gajda, Ken Murchison
 

--- a/sources/sections/99-acknowledgements.adoc
+++ b/sources/sections/99-acknowledgements.adoc
@@ -1,0 +1,11 @@
+[acknowledgments]
+== Acknowledgements
+
+The author would also like to thank the members of the CalConnect Calendar Sharing
+technical committee and the following individuals for contributing their ideas and
+support:
+
+Marten Gajda, Ken Murchison
+
+The authors would also like to thank CalConnect the Calendaring and Scheduling
+Consortium for advice with this specification.


### PR DESCRIPTION
Closes #2 .

Notes:
* The structure of this document differs in that "Conventions" is a subsection of the Introduction. In most documents, "Conventions" is a separate section following the Introduction, and for those documents, I have renamed "Conventions" to "Terms and Definitions" in CC version to align with CC's format. In this case, the original structure remains unchanged. Please let me know if any adjustments are needed.
* Open Issues subsection under Abstract is encoded in the IETF version only. Please let me know if it needs to be added to the CC version as well.